### PR TITLE
Address PE-D issues highlighted #5

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -177,9 +177,9 @@ General Format: `delete [FLAG] [INPUT]`
     * Example: delete 1-5
 
 ### Exiting the Program: `exit`
-Terminates the program.
-    * Command: `exit`
-        * Exit Inventra.
+Terminates the program.  
+    * Command: `exit`  
+        * Exit Inventra.  
         * Example:
         ``` exit ```
 

--- a/src/main/java/seedu/command/AddCommand.java
+++ b/src/main/java/seedu/command/AddCommand.java
@@ -166,9 +166,17 @@ public class AddCommand extends Command {
                 throw new InventraInvalidTypeException(field, value, "non-numeric string");
             }
             return null; // Any string is valid
+
         case "i": // Integer
             try {
-                int intValue = Integer.parseInt(value);
+                if (value.length() > 9) { // Restrict integer length to 9 digits
+                    throw new InventraInvalidTypeException(
+                            String.format("Error: Invalid type for field '%s'%n" +
+                                            "Expected value of type 'integer (up to 9 digits)', got: '%s'",
+                                    field, value)
+                    );
+                }
+                int intValue = Integer.parseInt(value); // Validates actual integer
                 if (intValue < 0) {
                     throw new InventraNegativeValueException(field, value);
                 }
@@ -176,6 +184,7 @@ public class AddCommand extends Command {
             } catch (NumberFormatException e) {
                 throw new InventraInvalidTypeException(field, value, "integer");
             }
+
         case "f": // Float
             try {
                 float floatValue = Float.parseFloat(value);
@@ -186,31 +195,36 @@ public class AddCommand extends Command {
             } catch (NumberFormatException e) {
                 throw new InventraInvalidTypeException(field, value, "float");
             }
+
         case "d": // Date
-            String[] parts = value.split("/");
-            if (parts.length != 3) {
+            if (!value.matches("\\d{2}/\\d{2}/\\d{4}") && !value.matches("\\d{2}/\\d{2}/\\d{2}")) {
                 throw new InventraInvalidTypeException(
-                        field,
-                        value,
-                        "date (expected format: DD/MM/YYYY or DD/MM/YY)"
+                        field, value, "date (expected format: DD/MM/YYYY or DD/MM/YY)"
                 );
             }
+            String[] parts = value.split("/");
             try {
                 int day = Integer.parseInt(parts[0]);
                 int month = Integer.parseInt(parts[1]);
                 int year = Integer.parseInt(parts[2]);
                 if (day <= 0 || day > 31 || month <= 0 || month > 12 || year < 0) {
-                    throw new InventraInvalidTypeException(field, value, "valid date in DD/MM/YYYY or DD/MM/YY format");
+                    throw new InventraInvalidTypeException(
+                            field, value, "valid date in DD/MM/YYYY or DD/MM/YY format"
+                    );
                 }
                 return null; // Valid date
             } catch (NumberFormatException e) {
-                throw new InventraInvalidTypeException(field, value, "valid date (DD/MM/YYYY or DD/MM/YY)");
+                throw new InventraInvalidTypeException(
+                        field, value, "valid date (DD/MM/YYYY or DD/MM/YY)"
+                );
             }
+
         case "n": // Null
             if (!value.equalsIgnoreCase("null")) {
                 throw new InventraInvalidTypeException(field, value, "null");
             }
             return null; // Valid null
+
         default:
             return ui.getUnknownTypeMessage(field);
         }

--- a/src/main/java/seedu/exceptions/InventraInvalidTypeException.java
+++ b/src/main/java/seedu/exceptions/InventraInvalidTypeException.java
@@ -1,19 +1,21 @@
 package seedu.exceptions;
 
 public class InventraInvalidTypeException extends InventraException {
-    private final String field;
-    private final String input;
-    private final String expectedType;
+    private final String customMessage;
 
     public InventraInvalidTypeException(String field, String input, String expectedType) {
-        this.field = field;
-        this.input = input;
-        this.expectedType = expectedType;
+        this.customMessage = String.format(
+                "Error: Invalid type for field '%s'%nExpected value of type '%s', got: '%s'",
+                field, expectedType, input
+        );
+    }
+
+    public InventraInvalidTypeException(String customMessage) {
+        this.customMessage = customMessage;
     }
 
     @Override
     public String getMessage() {
-        return "Error: Invalid type for field '" + field + "'\n" +
-                "Expected value of type '" + expectedType + "', got: '" + input + "'";
+        return customMessage;
     }
 }

--- a/src/test/java/seedu/command/AddCommandTest.java
+++ b/src/test/java/seedu/command/AddCommandTest.java
@@ -385,16 +385,19 @@ public class AddCommandTest {
 
     @Test
     public void testHFlagInsufficientDataError() {
-        // Test case with insufficient data for flag -h
-        String[] args = new String[]{"add", "-h", "field1"}; // Only three arguments, modify as needed
         AddCommand addCommand = new AddCommand(inventory, ui, csv);
-        InventraInvalidTypeException thrown = assertThrows(InventraInvalidTypeException.class, () -> {
-            addCommand.execute(args);
+        String expectedMessage = "Error: Invalid type for field 'Field format'\n" +
+                "Expected value of type 'correct format (type/fieldName)', got: 'field1'";
+
+        InventraException thrown = assertThrows(InventraInvalidTypeException.class, () -> {
+            // Simulate invalid field input
+            addCommand.execute(new String[]{"add", "-h", "field1"});
         });
 
-        assertEquals("Error: Invalid type for field 'Field format'\n"
-                + "Expected value of type 'correct format (type/fieldName)'"
-                + ", got: 'field1'", thrown.getMessage());
+        String actualMessage = thrown.getMessage();
+
+        // Normalize both expected and actual strings
+        assertEquals(expectedMessage.trim().replaceAll("\\s+", " "), actualMessage.trim().replaceAll("\\s+", " "));
     }
 
     @Test


### PR DESCRIPTION
18. "add -h n/" removed from UG in previous fixes [Close #126]

19. Formatting of "exit" program in UG (updated) [Close #124] [Closes #122]  ===> relook this one

20. Using a number exceeding range of 32-bit int (max at 2,147,483,647) throws error not valid number
- Resolved by setting limit to only 9 characters for integer type [Close #121]
- If length exceeds 9 digits, throw "InventraInvalidTypeException"