### PR TITLE
Address issues raised in PE-D #6

### DIFF
--- a/app.log
+++ b/app.log
@@ -276,3 +276,199 @@ Nov 10, 2024 3:26:42 AM seedu.command.AddCommand handleAddRecord
 INFO: Handling add record: value1
 Nov 10, 2024 3:26:42 AM seedu.command.AddCommand handleAddRecord
 INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:57:48 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:57:49 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:57:56 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:57:57 AM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 2:50:32 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 2:50:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:50:45 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 2:50:45 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 2:50:45 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 2:50:45 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:50:45 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 2:50:46 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 2:50:46 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 2:51:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:17:08 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:18:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:18:34 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:19:03 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:21:07 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:24:59 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:25:34 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:25:35 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:28:33 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:28:34 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:28:58 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50, extraValue
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple@!, 20, 2.99
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, ten, 1.50
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: value1
+Nov 10, 2024 3:29:11 PM seedu.command.AddCommand handleAddRecord
+INFO: Handling add record: Apple, 10, 1.50

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,6 +75,7 @@ Get help from manual page for inventra
 #### Display Help Page For Specific Command
 * Command: `help COMMAND`
 * Example: `help delete`
+* Note: COMMAND works for specific command, excluding `help` command itself!
 
 ### Adding New Fields and Records: `add`
 Add new fields or records to the inventory.
@@ -193,38 +194,38 @@ Ensure that the file remains in the same directory as `inventra.jar` file when r
 
 ## Known Issues
 
-1. Extra Input: Additional values provided after expected inputs for commands like `add -l`, `view -a`, `exit` will be ignored.
+1. Extra Input: Additional values provided after expected inputs for commands like `view -a`, `exit` will be ignored.
 2. Case Sensitivity: Ensure correct lowercase input as commands are case-sensitive.
 3. Pending Features: Increasing limitations of 20 character fields and records with dynamic output table Ui.
 
 ## Command Summary
 
-| Action                   | Format & Example                               |
-|--------------------------|------------------------------------------------|
-| **Get Help**             | `help` / `help [COMMAND]`                      |
-|                          | Example: `help` / `help delete`                |
-| **Add Field**            | `add -h TYPE/FIELD1, TYPE/FIELD2,...`          |
-|                          | Example: `add -h s/name, i/quantity, d/expiry` |
-| **Add Record**           | `add -d VALUE1, VALUE2,...`                    |
-|                          | Example: `add -d Apple, 100, 1.50, 01/10/2024` |
-| **View All Records**     | `view -a`                                      |
-|                          | Example: `view -a`                             |
-| **View Specific Record** | `view RECORD_ID`                               |
-|                          | Example: `view 1`                              |
-| **Update Field**         | `update -h OLDFIELD, NEWFIELD`                 |
-|                          | Example: `update -h name, product_name`        |
-| **Update Record**        | `update -d RECORD_ID, FIELD, NEWVALUE`         |
-|                          | Example: `update -d 1, price, 1.50`            |
-| **Delete All Fields**    | `delete -e`                                    |
-|                          | Example: `delete -e`                           |
-| **Delete All Records**   | `delete -a`                                    |
-|                          | Example: `delete -a`                           |
-| **Delete Field**         | `delete -h FIELD_NAME`                         |
-|                          | Example: `delete -h quantity`                  |
-| **Delete Specific Record**| `delete RECORD_ID`                             |
-|                          | Example: `delete 1`                            |
-| **Delete Range of Records**| `delete -r STARTID-ENDID`                      |
-|                          | Example: `delete -r 1-5`                       |
-| **Exit Program**         | `exit`                                         |
-|                          | Example: `exit`                                |
+| Action                   | Format & Example                                        |
+|--------------------------|---------------------------------------------------------|
+| **Get Help**             | `help` / `help [COMMAND]`                               |
+|                          | Example: `help` / `help delete`                         |
+| **Add Field**            | `add -h TYPE/FIELD1, TYPE/FIELD2,...`                   |
+|                          | Example: `add -h s/name, i/quantity, f/price, d/expiry` |
+| **Add Record**           | `add -d VALUE1, VALUE2,...`                             |
+|                          | Example: `add -d Apple, 100, 1.50, 01/10/2024`          |
+| **View All Records**     | `view -a`                                               |
+|                          | Example: `view -a`                                      |
+| **View Specific Record** | `view RECORD_ID`                                        |
+|                          | Example: `view 1`                                       |
+| **Update Field**         | `update -h OLDFIELD, NEWFIELD`                          |
+|                          | Example: `update -h name, product_name`                 |
+| **Update Record**        | `update -d RECORD_ID, FIELD, NEWVALUE`                  |
+|                          | Example: `update -d 1, price, 1.50`                     |
+| **Delete All Fields**    | `delete -e`                                             |
+|                          | Example: `delete -e`                                    |
+| **Delete All Records**   | `delete -a`                                             |
+|                          | Example: `delete -a`                                    |
+| **Delete Field**         | `delete -h FIELD_NAME`                                  |
+|                          | Example: `delete -h quantity`                           |
+| **Delete Specific Record**| `delete RECORD_ID`                                      |
+|                          | Example: `delete 1`                                     |
+| **Delete Range of Records**| `delete -r STARTID-ENDID`                               |
+|                          | Example: `delete -r 1-5`                                |
+| **Exit Program**         | `exit`                                                  |
+|                          | Example: `exit`                                         |
 

--- a/src/main/java/seedu/command/UpdateCommand.java
+++ b/src/main/java/seedu/command/UpdateCommand.java
@@ -52,28 +52,36 @@ public class UpdateCommand extends Command {
     }
 
     private void handleUpdateField(String fieldData) throws InventraException {
+        if (!fieldData.contains(",")) {
+            throw new InventraMissingArgsException(
+                    "Expected format: <old_field>, <new_field>.\n Ensure you separate the old and " +
+                            "new field names with a comma."
+            );
+        }
+
         String[] fields = fieldData.split(",\\s*");
 
-        if (fields.length > 2) {
-            throw new InventraExcessArgsException(2, fields.length);
-        } else if (fields.length < 2) {
+        if (fields.length < 2) {
             throw new InventraLessArgsException(2, fields.length);
+        } else if (fields.length > 2) {
+            throw new InventraExcessArgsException(2, fields.length);
         }
 
         String oldFieldName = fields[0].trim();
         String newFieldName = fields[1].trim();
 
         if (oldFieldName.isEmpty() || newFieldName.isEmpty()) {
-            throw new InventraInvalidTypeException("Field names",
-                    "cannot be empty or just spaces", "provide valid field names");
+            throw new InventraInvalidTypeException("Field names", "cannot be empty", "provide valid field names");
         }
 
-        if (oldFieldName.length() > 20 || newFieldName.length() > 20) {
+        // Allow update if new field name is valid, even if old field name exceeds limit
+        if (newFieldName.length() > 20) {
             throw new InventraInvalidTypeException("Field name length",
                     "exceeds 20 characters", "use shorter names");
         }
 
-        if (!isFieldValid(oldFieldName)) {
+        // Bypass validation for oldFieldName to allow corrective action
+        if (!inventory.getFields().contains(oldFieldName)) {
             throw new InventraInvalidHeaderException(oldFieldName);
         }
 

--- a/src/main/java/seedu/exceptions/InventraException.java
+++ b/src/main/java/seedu/exceptions/InventraException.java
@@ -1,8 +1,12 @@
 package seedu.exceptions;
 
 public class InventraException extends Exception {
-    @Override
-    public String getMessage() {
-        return "Error: An error has occurred";
+    public InventraException(String message) {
+        super(message);
+    }
+
+    public InventraException() {
+        super("Error: An error has occurred");
     }
 }
+

--- a/src/main/java/seedu/exceptions/InventraLessArgsException.java
+++ b/src/main/java/seedu/exceptions/InventraLessArgsException.java
@@ -9,7 +9,9 @@ public class InventraLessArgsException extends InventraException {
         this.actual = actual;
     }
 
+    @Override
     public String getMessage() {
-        return "Error: Less arguments than required, expected: " + expected + ", received " + actual;
+        return String.format("Error: Less arguments than required, expected: %d, received: %d", expected, actual);
     }
 }
+

--- a/src/main/java/seedu/inventra/Inventra.java
+++ b/src/main/java/seedu/inventra/Inventra.java
@@ -10,8 +10,8 @@ public class Inventra {
         Inventory inventory = new Inventory(); // Instantiate Inventory here
         Csv csv = new Csv("data/inventory.csv");
 
-        // Load existing records from CSV
         csv.loadInventoryFromCsv(inventory);
+
         ui.run(inventory, csv);
     }
 }

--- a/src/test/java/seedu/command/UpdateCommandTest.java
+++ b/src/test/java/seedu/command/UpdateCommandTest.java
@@ -12,6 +12,7 @@ import seedu.exceptions.InventraOutOfBoundsException;
 import seedu.exceptions.InventraExcessArgsException;
 import seedu.exceptions.InventraLessArgsException;
 import seedu.exceptions.InventraInvalidHeaderException;
+import seedu.exceptions.InventraMissingArgsException;
 import seedu.model.Inventory;
 import seedu.storage.Csv;
 import seedu.ui.Ui;
@@ -77,26 +78,6 @@ public class UpdateCommandTest {
     }
 
     @Test
-    public void execute_updateFieldWithInvalidOldField_throwsException() {
-        String[] updateFieldArgs = {"update", "-h", "invalidField, newName"};
-        UpdateCommand updateCommand = new UpdateCommand(inventory, ui, csv);
-
-        assertThrows(InventraInvalidHeaderException.class, () -> {
-            updateCommand.execute(updateFieldArgs);
-        });
-    }
-
-    @Test
-    public void execute_updateFieldWithLessArgs_throwsException() {
-        String[] updateFieldArgs = {"update", "-h", "name"};
-        UpdateCommand updateCommand = new UpdateCommand(inventory, ui, csv);
-
-        assertThrows(InventraLessArgsException.class, () -> {
-            updateCommand.execute(updateFieldArgs);
-        });
-    }
-
-    @Test
     public void execute_updateFieldWithExcessArgs_throwsException() {
         String[] updateFieldArgs = {"update", "-h", "name,newName,extraArg"};
         UpdateCommand updateCommand = new UpdateCommand(inventory, ui, csv);
@@ -104,6 +85,34 @@ public class UpdateCommandTest {
         assertThrows(InventraExcessArgsException.class, () -> {
             updateCommand.execute(updateFieldArgs);
         });
+    }
+
+    @Test
+    void execute_updateFieldWithInvalidFormat_throwsMissingArgsException() {
+        UpdateCommand command = new UpdateCommand(inventory, ui, csv);
+        String input = "fieldAfieldB";  // Missing comma
+
+        InventraMissingArgsException thrown = assertThrows(
+                InventraMissingArgsException.class,
+                () -> command.execute(new String[] { "update", "-h", input })
+        );
+
+        assertEquals("Error: Missing the following arguments:" +
+                " Expected format: <old_field>, <new_field>.\n Ensure you separate " +
+                "the old and new field names with a comma.", thrown.getMessage());
+    }
+
+    @Test
+    void execute_updateFieldWithLessArgs_throwsLessArgsException() {
+        UpdateCommand command = new UpdateCommand(inventory, ui, csv);
+        String input = "fieldA,";  // Comma included, but missing second argument
+
+        InventraLessArgsException thrown = assertThrows(
+                InventraLessArgsException.class,
+                () -> command.execute(new String[] { "update", "-h", input })
+        );
+
+        assertEquals("Error: Less arguments than required, expected: 2, received: 1", thrown.getMessage());
     }
 
     @Test


### PR DESCRIPTION
v2.1-fix-PE-D-#6

21. [Issue #87]: Implemented header length validation on load, and user guidance on fixing corrupted header
- via integration of [validateHeadersOnLoad] method on CSV loading. [Close #87]

22. [Issue #92]: Enhance prompt when user forgets to include commas while using the 'update -h' command. [Close #92] & [Close #101] - related issues.

23. Updated UserGuide to ensure smooth testing process annotated in Command Summary Table. [Close #93] Annotation to inform at `help help` does not exist. [Close #98] As well as spacing in FAQ resolved. [Close #99] Removed `add -l` from documentation - debunked feature. [Close #103] Resolved removal of n/ [Close #104]
